### PR TITLE
feat(emergency-recovery): require Read tool before LLM diagnosis (anti-hallucination guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+- **emergency-recovery.sh** — Level 3 LLM prompt now includes a "MANDATORY FIRST STEPS"
+  block requiring Read tool calls (README.md / `~/.openclaw/openclaw.json` / recent logs /
+  watchdog scripts) **before** diagnosis. Reduces hallucination risk where Claude attempts
+  recovery without first reading actual system state. The prompt also asks Claude to log
+  the Read tool invocation count to the report file for post-incident audit.
+
+---
+
 ## [3.1.0] - 2026-02-21
 
 ### Fixed

--- a/scripts/emergency-recovery.sh
+++ b/scripts/emergency-recovery.sh
@@ -225,14 +225,24 @@ main() {
   local recovery_command
   recovery_command="OpenClaw 게이트웨이가 5분간 재시작했으나 복구되지 않았습니다. 긴급 진단 및 복구를 시작하세요.
 
-작업 순서:
+# MANDATORY FIRST STEPS (Read tool 호출 필수 — 진단 전 반드시 수행)
+- 진단·복구 시도 전에 다음 중 **최소 2개**를 Read tool로 직접 읽어라.
+- Read tool 호출 없이 진단할 경우 할루시네이션 위험 — 실제 시스템 상태를 모르면서 추측 처방하게 된다.
+- 본 단계 누락 시 결과는 신뢰할 수 없으며 $REPORT_FILE 에 'tool_use=0 (할루시네이션 의심)'으로 기록하라.
+
+  1. README.md  (전체 self-healing 4-tier chain — Level 1~3 흐름)
+  2. ~/.openclaw/openclaw.json  (현재 게이트웨이 설정)
+  3. ~/.openclaw/logs/*.log 최신 라인  (실제 에러 메시지)
+  4. ./scripts/gateway-watchdog.sh 또는 ./scripts/gateway-healthcheck.sh  (Level 1~2 동작)
+
+작업 순서 (위 MANDATORY 완료 후):
 1. \`openclaw status\` 체크
 2. 로그 분석 (~/.openclaw/logs/*.log)
 3. 설정 검증 (~/.openclaw/openclaw.json)
 4. 포트 충돌 체크 (\`lsof -i :18789\`)
 5. 의존성 체크 (\`npm list\`, \`node --version\`)
 6. 복구 시도 (설정 수정, 프로세스 재시작)
-7. 결과를 $REPORT_FILE 에 기록
+7. 결과를 $REPORT_FILE 에 기록 (Read tool 호출 횟수도 함께 기록)
 
 작업 제한시간: ${RECOVERY_TIMEOUT}초 이내
 목표: Gateway가 $GATEWAY_URL 에서 HTTP 200 응답하도록 복구"


### PR DESCRIPTION
## Summary

Adds a "MANDATORY FIRST STEPS" block to the Level 3 emergency-recovery prompt requiring Claude to read at least 2 of {README.md, openclaw.json, recent logs, watchdog scripts} via the Read tool **before** attempting diagnosis or recovery.

## Why

In a companion project (`jarvis-supervisor`, an internal self-healing layer for a Discord bot + cron stack), I observed Claude completing recovery sessions with **`tool_use=0`** — no Read tool calls at all. The model produced plausible-looking diagnoses ("checking the indexer", "reviewing logs") without actually inspecting any file. Pure hallucination path.

The fix in jarvis was a two-layer guard:
1. **Prompt-level** — explicitly require Read tool calls before diagnosis
2. **Wrapper-level** — grep the session log post-hoc for tool_use count, mark `tool_use=0` runs as `fail-quality` regardless of LLM's `result:success`

This PR ports **layer 1** to openclaw — the prompt-level requirement. It also asks Claude to write the Read tool invocation count to `$REPORT_FILE` so post-incident audit can flag low-confidence runs without changing the wrapper.

Layer 2 (a wrapper grep) is intentionally **not** in this PR — it would touch control flow and metric recording, deserves its own PR after layer 1 settles.

## What changed

- `scripts/emergency-recovery.sh` — added MANDATORY FIRST STEPS block to `recovery_command` (10 lines). No control flow change.
- `CHANGELOG.md` — added Unreleased entry.

## Risk

**Low.** Prompt-text-only change. No dependency / shell logic / metric format modified. Worst case: Claude reads more files before fixing, slightly higher token cost. Best case: hallucinated recoveries are caught before they break production.

## Validation

- `bash -n scripts/emergency-recovery.sh` → OK
- ShellCheck unchanged (pre-existing SC1091 on `lib/notify.sh` source — not introduced here)
- Functional validation pending — jarvis-supervisor that originated this pattern only started gathering its own dry-run data on 2026-05-07, so I don't yet have multi-day "recovery rate before/after" numbers to attach.

## Notes

- The companion guard (layer 2 — `tool_use=0` post-hoc check) is a separate PR if interesting.
- Same pattern would apply to `emergency-recovery-v2.sh`, but v2 is currently a 1-line stub in this repo so I left it alone.